### PR TITLE
Add YAML frontmatter to all SKILL.md files for plugin discovery

### DIFF
--- a/teampowers/skills/ad-hoc-agents/SKILL.md
+++ b/teampowers/skills/ad-hoc-agents/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: ad-hoc-agents
+description: Dynamically create specialized agents based on task domain requirements
+---
+
 # Ad Hoc Agents
 
 ## Metadata

--- a/teampowers/skills/brainstorming/SKILL.md
+++ b/teampowers/skills/brainstorming/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: brainstorming
+description: Structured brainstorming before implementation — refine ideas, explore alternatives, validate design
+---
+
 # Brainstorming
 
 ## Metadata

--- a/teampowers/skills/ci/SKILL.md
+++ b/teampowers/skills/ci/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: ci
+description: Continuous integration agent that runs builds, tests, linting, and type checking — first in dev worktrees, then on the merged feature branch
+---
+
 # CI Agent
 
 ## Metadata

--- a/teampowers/skills/communication-mesh/SKILL.md
+++ b/teampowers/skills/communication-mesh/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: communication-mesh
+description: Architectural overview of how agents communicate — each agent's specific paths are in its own skill file
+---
+
 # Communication Mesh — Architectural Overview
 
 ## Metadata

--- a/teampowers/skills/dev/SKILL.md
+++ b/teampowers/skills/dev/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dev
+description: Implementation agent that writes production code based on task specs, guided by scout context and TDD
+---
+
 # Dev Agent
 
 ## Metadata

--- a/teampowers/skills/executing-plans/SKILL.md
+++ b/teampowers/skills/executing-plans/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: executing-plans
+description: Execute an implementation plan with batch execution, team pipeline, and human review checkpoints
+---
+
 # Executing Plans
 
 ## Metadata

--- a/teampowers/skills/finishing-a-development-branch/SKILL.md
+++ b/teampowers/skills/finishing-a-development-branch/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: finishing-a-development-branch
+description: Complete a development branch with final verification and cleanup
+---
+
 # Finishing a Development Branch
 
 ## Metadata

--- a/teampowers/skills/reviewer/SKILL.md
+++ b/teampowers/skills/reviewer/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: reviewer
+description: Two-stage code review agent — spec compliance first, then code quality — reviews in the dev's worktree before merge
+---
+
 # Reviewer Agent
 
 ## Metadata

--- a/teampowers/skills/scout/SKILL.md
+++ b/teampowers/skills/scout/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: scout
+description: Reconnaissance agent that explores the codebase, maps architecture, and gathers context before development begins
+---
+
 # Scout Agent
 
 ## Metadata

--- a/teampowers/skills/systematic-debugging/SKILL.md
+++ b/teampowers/skills/systematic-debugging/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: systematic-debugging
+description: Methodical approach to diagnosing and fixing bugs — no guessing
+---
+
 # Systematic Debugging
 
 ## Metadata

--- a/teampowers/skills/team-driven-development/SKILL.md
+++ b/teampowers/skills/team-driven-development/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: team-driven-development
+description: Orchestrate a team of specialized agents — verify in dev worktrees before merge, agents communicate directly
+---
+
 # Team-Driven Development
 
 ## Metadata

--- a/teampowers/skills/test-driven-development/SKILL.md
+++ b/teampowers/skills/test-driven-development/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: test-driven-development
+description: Write tests before implementation code — the iron rule of teampowers
+---
+
 # Test-Driven Development
 
 ## Metadata

--- a/teampowers/skills/tester/SKILL.md
+++ b/teampowers/skills/tester/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: tester
+description: Test-first agent that writes failing tests before implementation and validates behavior after — in the dev's worktree
+---
+
 # Tester Agent
 
 ## Metadata

--- a/teampowers/skills/using-git-worktrees/SKILL.md
+++ b/teampowers/skills/using-git-worktrees/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: using-git-worktrees
+description: Use Claude Code's native worktree support to give each agent an isolated working directory
+---
+
 # Using Git Worktrees
 
 ## Metadata

--- a/teampowers/skills/using-teampowers/SKILL.md
+++ b/teampowers/skills/using-teampowers/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: using-teampowers
+description: Entry point — how teampowers works, the team roster, and when to activate each skill
+---
+
 # Using Teampowers
 
 ## Metadata

--- a/teampowers/skills/verification-before-completion/SKILL.md
+++ b/teampowers/skills/verification-before-completion/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: verification-before-completion
+description: Verify all work before marking anything as complete
+---
+
 # Verification Before Completion
 
 ## Metadata

--- a/teampowers/skills/writing-plans/SKILL.md
+++ b/teampowers/skills/writing-plans/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: writing-plans
+description: Create structured implementation plans that can be executed by teams or sequentially
+---
+
 # Writing Plans
 
 ## Metadata

--- a/teampowers/skills/writing-skills/SKILL.md
+++ b/teampowers/skills/writing-skills/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: writing-skills
+description: How to create new teampowers skills
+---
+
 # Writing Skills
 
 ## Metadata
@@ -11,6 +16,19 @@ Skills are markdown files in `skills/{skill-name}/SKILL.md` that teach Claude Co
 ## Skill Structure
 
 Every skill needs:
+
+### 0. YAML Frontmatter (Required)
+
+The file MUST start with YAML frontmatter — this is how Claude Code discovers and registers skills:
+
+```markdown
+---
+name: skill-name
+description: One-line description of what this skill does
+---
+```
+
+Without frontmatter, the skill won't be discovered by the plugin system.
 
 ### 1. Metadata
 ```markdown
@@ -45,6 +63,7 @@ Which other teampowers skills this one connects to.
 ## Adding a New Skill
 
 1. Create `skills/{skill-name}/SKILL.md`
-2. Follow the structure above
-3. Add integration references to related skills
-4. Test the skill by using it in a real workflow
+2. Add YAML frontmatter with `name` and `description` (required for plugin discovery)
+3. Follow the structure above
+4. Add integration references to related skills
+5. Test the skill by using it in a real workflow


### PR DESCRIPTION
Claude Code requires YAML frontmatter (--- delimited block with name and description fields) at the top of each SKILL.md for the plugin system to discover and register skills. Without it, skills aren't loadable when the plugin is installed. Also updated writing-skills to document this requirement.

https://claude.ai/code/session_01H8ZbM7eTHg2tV3mHuiRX22